### PR TITLE
Add modern dark theme via qdarktheme

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,24 +1,16 @@
 # app/__main__.py
 from __future__ import annotations
 import asyncio, signal, sys
-from pathlib import Path
-
 from PySide6.QtWidgets import QApplication
 from qasync import QEventLoop
 
 from .gui.mainwindow import MainWindow
 
 
-def _load_global_qss() -> str:
-    """читаем файл gui/style_light.qss (лежит рядом с mainwindow.py)"""
-    qss_path = Path(__file__).parent / "gui" / "style_light.qss"
-    return qss_path.read_text(encoding="utf-8")
-
-
 def main() -> None:
     app = QApplication(sys.argv)
     app.setStyle("Fusion")                       # базовый светлый стиль
-    app.setStyleSheet(_load_global_qss())        # наш QSS — один раз для всего приложения
+    # тема применяется в MainWindow
 
     loop = QEventLoop(app)
     asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Summary
- enhance GUI by importing qdarktheme
- add "modern" theme option in settings
- set modern theme as default
- apply qdarktheme when modern theme is selected
- tidy main entry point to let MainWindow manage themes

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6c8a6bc4832dbbf0afb29841cf3d