### PR TITLE
Refine themes and fix settings UI

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,24 +1,16 @@
 # app/__main__.py
 from __future__ import annotations
 import asyncio, signal, sys
-from pathlib import Path
-
 from PySide6.QtWidgets import QApplication
 from qasync import QEventLoop
 
 from .gui.mainwindow import MainWindow
 
 
-def _load_global_qss() -> str:
-    """читаем файл gui/style_light.qss (лежит рядом с mainwindow.py)"""
-    qss_path = Path(__file__).parent / "gui" / "style_light.qss"
-    return qss_path.read_text(encoding="utf-8")
-
-
 def main() -> None:
     app = QApplication(sys.argv)
     app.setStyle("Fusion")                       # базовый светлый стиль
-    app.setStyleSheet(_load_global_qss())        # наш QSS — один раз для всего приложения
+    # тема применяется в MainWindow
 
     loop = QEventLoop(app)
     asyncio.set_event_loop(loop)

--- a/app/gui/style_graphite.qss
+++ b/app/gui/style_graphite.qss
@@ -1,18 +1,18 @@
 /* мягкий графит #383838 + акцент #ff9f40 */
-QMainWindow        { background:#383838; }
+QMainWindow        { background:#2f2f2f; }
 
-QToolBar           { background:#474747; spacing:24px; padding:10px 20px; border:none; }
-QToolButton        { background:#5c5c5c; color:#f0f0f0; border:none; border-radius:10px;
-                     width:90px; height:90px; font:11pt 'Segoe UI'; }
-QToolButton:hover  { background:#6b6b6b; }
-QToolButton:pressed{ background:#7a7a7a; }
+QToolBar           { background:#3a3a3a; spacing:16px; padding:8px 16px; border:none; }
+QToolButton        { background:#555; color:#f0f0f0; border:none; border-radius:8px;
+                     width:80px; height:80px; font:11pt 'Segoe UI'; }
+QToolButton:hover  { background:#666; }
+QToolButton:pressed{ background:#777; }
 
-#Title             { font:700 22px 'Segoe UI'; color:#ffffff; margin-bottom:6px; }
-#Header            { font:600 12pt 'Segoe UI'; color:#dcdcdc; }
+#Title             { font:700 24px 'Segoe UI'; color:#ffffff; margin-bottom:6px; }
+#Header            { font:600 13px 'Segoe UI'; color:#dcdcdc; }
 #StageLabel        { font:700 18px 'Segoe UI'; color:#ffb347; }
 
-QPlainTextEdit     { background:#2e2e2e; color:#e6e6e6; border:1px solid #555;
-                     border-radius:8px; padding:6px; font:12pt 'Consolas'; }
+QPlainTextEdit     { background:#222; color:#e6e6e6; border:1px solid #555;
+                     border-radius:10px; padding:6px; font:12pt 'Consolas'; }
 
-QProgressBar       { background:#444; border:1px solid #666; border-radius:6px; height:16px; }
+QProgressBar       { background:#3c3c3c; border:1px solid #555; border-radius:6px; height:16px; }
 QProgressBar::chunk{ background:#ff9f40; border-radius:6px; }

--- a/app/gui/style_light.qss
+++ b/app/gui/style_light.qss
@@ -1,42 +1,42 @@
-QMainWindow { background:#faf3e0; }
+QMainWindow { background:qlineargradient(x1:0,y1:0,x2:0,y2:1,stop:0 #fcf4e9, stop:1 #f7e8d0); }
 
 /* тулбар и кнопки -------------------------------------------------------*/
 QToolBar {
     background:#ffffff;
-    spacing:24px;
-    padding:10px 20px;
+    spacing:16px;
+    padding:8px 16px;
     border:none;
 }
 QToolButton {
-    background:#ffd7b3;
+    background:#ffcc99;
     border:none;
-    border-radius:10px;
-    padding:10px;
+    border-radius:8px;
+    padding:8px;
     color:#4a3f35;
-    width:90px; height:90px;
+    width:80px; height:80px;
     font:11pt 'Segoe UI';
 }
-QToolButton:hover   { background:#ffcc99; }
-QToolButton:pressed { background:#ffbf80; }
+QToolButton:hover   { background:#ffb366; }
+QToolButton:pressed { background:#ffa64d; }
 
 /* заголовки -------------------------------------------------------------*/
-#Title       { font:700 22px 'Segoe UI'; color:#564e46; margin-bottom:6px; }
-#Header      { font:600 12pt 'Segoe UI'; color:#6d6257; }
+#Title       { font:700 24px 'Segoe UI'; color:#5a5047; margin-bottom:6px; }
+#Header      { font:600 13px 'Segoe UI'; color:#6d6257; }
 #StageLabel  { font:700 18px 'Segoe UI'; color:#ff8c1a; }
 
 /* текстовые поля --------------------------------------------------------*/
 QPlainTextEdit {
-    background:#fffdf8;
+    background:#fffaf3;
     color:#3e3a35;
     border:1px solid #e0d8cf;
-    border-radius:8px;
+    border-radius:10px;
     padding:6px;
     font:12pt 'Consolas';
 }
 
 /* прогресс-бар ----------------------------------------------------------*/
 QProgressBar {
-    background:#f1ebe4;
+    background:#f2e7d7;
     border:1px solid #d8cfc5;
     border-radius:6px;
     min-width:260px;

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,18 +283,6 @@ files = [
 ]
 
 [[package]]
-name = "darkdetect"
-version = "0.7.1"
-description = "Detect OS Dark Mode from Python"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "darkdetect-0.7.1-py2.py3-none-any.whl", hash = "sha256:3efe69f8ecd5f1b7f4fbb0d1d93f656b0e493c45cc49222380ffe2a529cbc866"},
-    {file = "darkdetect-0.7.1.tar.gz", hash = "sha256:47be3cf5134432ddb616bbffc927237718407914993c82809983e7ccebf49013"},
-]
-
-[[package]]
 name = "ffmpeg-python"
 version = "0.2.0"
 description = "Python bindings for FFmpeg - with complex filtering support"
@@ -4686,21 +4674,6 @@ pyobjc-core = ">=11.0"
 pyobjc-framework-Cocoa = ">=11.0"
 
 [[package]]
-name = "pyqtdarktheme"
-version = "2.1.0"
-description = "Flat dark theme for PySide and PyQt."
-optional = false
-python-versions = ">=3.7,<3.12"
-groups = ["main"]
-files = [
-    {file = "pyqtdarktheme-2.1.0-py3-none-any.whl", hash = "sha256:8739d99502230fbaca42551ea033c9ae31c81c4ebfec2f1ffde38f32a18bea7a"},
-    {file = "pyqtdarktheme-2.1.0.tar.gz", hash = "sha256:5f8274ddfa3a5481ed9743cdb0f9debfeb7ff695b3a0d202a8104361d17dadb8"},
-]
-
-[package.dependencies]
-darkdetect = ">=0.7.1,<0.8.0"
-
-[[package]]
 name = "pyside6"
 version = "6.9.0"
 description = "Python bindings for the Qt cross-platform application and UI framework"
@@ -5291,4 +5264,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11,<3.12"
-content-hash = "179edaed62e3c14468a85ef5432b2e3948c3861a38bdcec42bfebfcd99cbcd73"
+content-hash = "9d490ca4ef4b932636441dfac774bb8b1a91d047fcad9ce3b17cad76df9eed07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ python          = "^3.11,<3.12"
 pyside6         = "^6.7"          # Qt 6 GUI
 qasync          = "^0.27"         # asyncio ↔ Qt bridge
 qtawesome       = "^1.3"          # FontAwesome иконки
-pyqtdarktheme   = {version="^2.1", python="<3.12"}
 openai-whisper  = "*"             # STT (CPU)
 aiohttp         = "^3.9"
 numpy           = "^1.26"


### PR DESCRIPTION
## Summary
- remove qdarktheme and modern theme option
- modernize light and graphite QSS styles
- use button groups to separate style and theme options
- add fade animation for stage label
- clean dependencies

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6c8a6bc4832dbbf0afb29841cf3d