### PR TITLE
Handle Ollama error response

### DIFF
--- a/app/workflows/summarizer.py
+++ b/app/workflows/summarizer.py
@@ -49,6 +49,9 @@ async def summarize(text: str, *, model: str, style: str) -> str:
         except aiohttp.ClientConnectionError as e:
             raise RuntimeError("Ollama не запущен.") from e
 
+    if "error" in data:
+        raise RuntimeError(data["error"])
+
     response = data.get("response") or ""
     response = re.sub(r"<think>.*?</think>", "", response, flags=re.S)
     # заменяем plain-таймкоды на кликабельный вид ▶ 00:12


### PR DESCRIPTION
## Summary
- raise an explicit `RuntimeError` when Ollama returns an error

## Testing
- `python -m py_compile app/workflows/summarizer.py`
- `curl -X POST http://localhost:11434/api/generate -d '{"model":"foobar","prompt":"test","stream":false}' -H "Content-Type: application/json"` *(fails: couldn't connect)*

------
https://chatgpt.com/codex/tasks/task_e_68546bc01ea8832da6ba6e306a34d3e5